### PR TITLE
Add CI with Miri tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  # I'm just one person so I don't really care about pushes to `main`
+  # right now - just want to make sure new PRs aren't sloppy.
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Format
+      run: cargo fmt --check
+    - name: Clippy
+      run: cargo clippy --all-targets
+    - name: Setup Miri
+      run: cargo miri setup
+    - name: Run tests with Miri
+      run: cargo miri test --verbose

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2023-02-21"
+components = ["clippy", "miri", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
## This Commit

Adds a basic action file to run lints and tests. It follows [this][miri] to ensure Miri is setup.

## Why?

Because Miri seems better at catching races than `loom`. Might remove `loom` since I can't get it to pass for the spin lock anyway.

[miri]: https://github.com/rust-lang/miri#running-miri-on-ci