### PR TITLE
Fix generic trait bounds in impl Sync for SpinLock

### DIFF
--- a/src/spin_lock/mod.rs
+++ b/src/spin_lock/mod.rs
@@ -34,10 +34,10 @@ impl<'a, T> DerefMut for SpinLockGuard<'a, T> {
     }
 }
 
-// SAFETY: If we're sharing the lock then the other thread can't get a `T` - only a `&/&mut T` so
-// we just need `T` to be `Sync`. The locking mechanism ensures that two shared versions don't get
-// mutable access concurrently.
-unsafe impl<T> Sync for SpinLock<T> where T: Sync {}
+// SAFETY: We need `T: Send` so we can access `&mut T` (and even `&T`!) on another thread. Because
+// the lock ensures exclusive access, we don't need `T: Sync` - that's only required if multiple
+// threads need to concurrently access `&T`.
+unsafe impl<T> Sync for SpinLock<T> where T: Send {}
 
 pub struct SpinLock<T> {
     data: UnsafeCell<T>,


### PR DESCRIPTION
## This Commit

Updates the bounds on `T` for `SpinLock` to implement `Sync`. This closes https://github.com/mlodato517/rust_atomics_and_locks/issues/1.

## Why?

When reviewing my code and comparing it with the book's implementation, I noticed I had the incorrect bounds when implementing `Sync` for `SpinLock`. I had required `T: Sync` when the book had `T: Send`.

I had erroneously thought that `Send` is only required when transferring owned values to other threads. See the comments in the issue for more details but I learned that `Send` is required to access `T`, `&T`, or `&mut T` _at all_ on another thread. `Sync` is _only_ required if concurrent access is required.